### PR TITLE
회원 권한 추가 

### DIFF
--- a/src/main/java/study/tdd/simpleboard/api/member/entity/Member.java
+++ b/src/main/java/study/tdd/simpleboard/api/member/entity/Member.java
@@ -3,11 +3,11 @@ package study.tdd.simpleboard.api.member.entity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -21,11 +21,26 @@ public class Member {
     private String nickname;
     private String password;
 
-    @Builder
+
+    @OneToMany(orphanRemoval = true, cascade = CascadeType.ALL, mappedBy = "member")
+    private List<MemberRole> memberRoleList = new ArrayList<>();
+
     public Member(String memberEmail, String nickname, String password) {
         this.memberEmail = memberEmail;
         this.nickname = nickname;
         this.password = password;
     }
 
+    @Builder
+    public Member(String memberEmail, String nickname, String password, Role memberRole) {
+        this.memberEmail = memberEmail;
+        this.nickname = nickname;
+        this.password = password;
+        this.memberRoleList.add(
+                MemberRole.builder()
+                        .role(memberRole)
+                        .member(this)
+                        .build()
+        );
+    }
 }

--- a/src/main/java/study/tdd/simpleboard/api/member/entity/MemberRepository.java
+++ b/src/main/java/study/tdd/simpleboard/api/member/entity/MemberRepository.java
@@ -1,9 +1,16 @@
 package study.tdd.simpleboard.api.member.entity;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNickname(String nickname);
+
+    @Query(value = "select DISTINCT m from Member m join fetch m.memberRoleList r where m.memberId = :id")
+    Optional<Member> findByMemberAllData(@Param("id") Long memberId);
 
 }

--- a/src/main/java/study/tdd/simpleboard/api/member/entity/MemberRole.java
+++ b/src/main/java/study/tdd/simpleboard/api/member/entity/MemberRole.java
@@ -1,0 +1,31 @@
+package study.tdd.simpleboard.api.member.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class MemberRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long roleId;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public MemberRole(Role role, Member member) {
+        this.role = role;
+        this.member = member;
+    }
+}

--- a/src/main/java/study/tdd/simpleboard/api/member/entity/Role.java
+++ b/src/main/java/study/tdd/simpleboard/api/member/entity/Role.java
@@ -1,0 +1,16 @@
+package study.tdd.simpleboard.api.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    ADMIN("ROLE_ADMIN"),
+    MEMBER("ROLE_MEMBER"),
+    BLOCK("ROLE_BLOCK");
+
+    private final String role;
+
+}

--- a/src/main/java/study/tdd/simpleboard/api/member/signup/dto/MemberSignUpRequestDTO.java
+++ b/src/main/java/study/tdd/simpleboard/api/member/signup/dto/MemberSignUpRequestDTO.java
@@ -2,8 +2,11 @@ package study.tdd.simpleboard.api.member.signup.dto;
 
 import lombok.*;
 import study.tdd.simpleboard.api.member.entity.Member;
+import study.tdd.simpleboard.api.member.entity.MemberRole;
+import study.tdd.simpleboard.api.member.entity.Role;
 
 import java.beans.ConstructorProperties;
+import java.util.ArrayList;
 
 /**
  * 회원가입을 위한 데이터들을 담아줄 DTO
@@ -28,6 +31,7 @@ public class MemberSignUpRequestDTO {
                 .nickname(nickname)
                 .password(password)
                 .memberEmail(memberEmail)
+                .memberRole(Role.MEMBER)
                 .build();
     }
 

--- a/src/main/java/study/tdd/simpleboard/filter/JWTFilter.java
+++ b/src/main/java/study/tdd/simpleboard/filter/JWTFilter.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -51,10 +52,9 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     private Authentication getAuthentication(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(NullPointerException::new);
+        Member member = memberRepository.findByMemberAllData(memberId).orElseThrow(NullPointerException::new);
 
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        List<GrantedAuthority> authorities = member.getMemberRoleList().stream().map(entity -> new SimpleGrantedAuthority(entity.getRole().getRole())).collect(Collectors.toList());
         UserDetails userDetails = new UserCustom(member, authorities);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);

--- a/src/main/java/study/tdd/simpleboard/filter/JWTFilter.java
+++ b/src/main/java/study/tdd/simpleboard/filter/JWTFilter.java
@@ -54,7 +54,10 @@ public class JWTFilter extends OncePerRequestFilter {
     private Authentication getAuthentication(Long memberId) {
         Member member = memberRepository.findByMemberAllData(memberId).orElseThrow(NullPointerException::new);
 
-        List<GrantedAuthority> authorities = member.getMemberRoleList().stream().map(entity -> new SimpleGrantedAuthority(entity.getRole().getRole())).collect(Collectors.toList());
+        List<GrantedAuthority> authorities = member.getMemberRoleList()
+                                                    .stream()
+                                                    .map(entity -> new SimpleGrantedAuthority(entity.getRole().getRole()))
+                                                    .collect(Collectors.toList());
         UserDetails userDetails = new UserCustom(member, authorities);
 
         return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);

--- a/src/test/java/study/tdd/simpleboard/api/member/entity/MemberRepositoryTest.java
+++ b/src/test/java/study/tdd/simpleboard/api/member/entity/MemberRepositoryTest.java
@@ -1,11 +1,18 @@
 package study.tdd.simpleboard.api.member.entity;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import study.tdd.simpleboard.api.member.signup.dto.MemberSignUpRequestDTO;
 
 import javax.persistence.EntityManager;
+import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,7 +31,11 @@ public class MemberRepositoryTest {
         String nickname = "Informix";
         String password = "q1w2e3";
         String memberEmail = "abc1234@naber.com";
-        Member wantToSaveMember = new Member(memberEmail, nickname, password);
+        Member wantToSaveMember = Member.builder()
+                .nickname(nickname)
+                .password(password)
+                .memberEmail(memberEmail)
+                .build();
 
         // 실행
         Member savedMember = memberRepository.save(wantToSaveMember);
@@ -40,7 +51,11 @@ public class MemberRepositoryTest {
         String nickname = "Informix";
         String password = "q1w2e3";
         String memberEmail = "abc1234@naver.com";
-        Member wantToSaveMember = new Member(memberEmail, nickname, password);
+        Member wantToSaveMember = Member.builder()
+                .nickname(nickname)
+                .password(password)
+                .memberEmail(memberEmail)
+                .build();
 
         // 실행
         Member saveMember = memberRepository.save(wantToSaveMember);
@@ -64,7 +79,11 @@ public class MemberRepositoryTest {
         String nickname = "Informix";
         String password = "q1w2e3";
         String memberEmail = "abc1234@naver.com";
-        Member wantToSaveMember = new Member(memberEmail, nickname, password);
+        Member wantToSaveMember = Member.builder()
+                .nickname(nickname)
+                .password(password)
+                .memberEmail(memberEmail)
+                .build();
 
         //when
         memberRepository.save(wantToSaveMember);
@@ -76,6 +95,24 @@ public class MemberRepositoryTest {
         boolean checkNickname = memberRepository.existsByNickname(nickname);
 
         assertThat(checkNickname).isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"nickname:password:pursue503@naver.com"}, delimiterString = ":")
+    @DisplayName("회원 정보 전체 가져오기 테스트")
+    public void findByMemberAllDataTest(String nickname, String password, String memberEmail) {
+
+        // 준비
+        MemberSignUpRequestDTO memberSignUpRequestDTO = new MemberSignUpRequestDTO(nickname, password, memberEmail);
+
+        Member saveMember = memberRepository.save(memberSignUpRequestDTO.toEntity());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Member findMember = memberRepository.findByMemberAllData(saveMember.getMemberId()).orElseThrow(NonUniqueResultException::new);
+
+        assertThat(findMember.getMemberRoleList().get(0).getRole()).isEqualTo(Role.MEMBER);
     }
 
 }


### PR DESCRIPTION
### 회원의 권한 추가

- 회원 권한 Entity 추가

- fetch join 으로 회원 권한까지 한번에 조회하는 Query 추가

- Filter 에서 회원 권한 직접 넣어주는 로직 추가 (stream)
```java

        List<GrantedAuthority> authorities = member.getMemberRoleList()
                                                    .stream()
                                                    .map(entity -> new SimpleGrantedAuthority(entity.getRole().getRole()))
                                                    .collect(Collectors.toList());
```