### PR TITLE
binding result aop

### DIFF
--- a/src/main/java/study/tdd/simpleboard/aop/BindingResultAop.java
+++ b/src/main/java/study/tdd/simpleboard/aop/BindingResultAop.java
@@ -1,0 +1,2 @@
+package study.tdd.simpleboard.aop;public class BindingResultAop {
+}

--- a/src/main/java/study/tdd/simpleboard/aop/BindingResultAop.java
+++ b/src/main/java/study/tdd/simpleboard/aop/BindingResultAop.java
@@ -1,2 +1,42 @@
-package study.tdd.simpleboard.aop;public class BindingResultAop {
+package study.tdd.simpleboard.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import study.tdd.simpleboard.exception.post.InvalidPostParameterException;
+import study.tdd.simpleboard.exception.post.PostCrudErrorCode;
+
+@Slf4j
+@Component
+@Aspect
+public class BindingResultAop {
+
+
+    /**
+     *
+     * api 패키지 내부 컨트롤러 실행전에 실행
+     *
+     * @param joinPoint
+     * @return
+     * @throws Throwable
+     */
+    @Before("execution(* study.tdd.simpleboard.api..*Controller.*(..))")
+    public void bindingBefore(JoinPoint joinPoint) throws Throwable {
+        for (Object arg : joinPoint.getArgs()) {
+            if (arg instanceof BindingResult) {
+                BindingResult result = (BindingResult) arg;
+
+                if (result.hasErrors()) {
+                    throw new InvalidPostParameterException(result, PostCrudErrorCode.POST_CRUD_FAIL);
+                }
+
+            }
+        } // end for
+    } // end
+
 }

--- a/src/main/java/study/tdd/simpleboard/api/post/controller/PostController.java
+++ b/src/main/java/study/tdd/simpleboard/api/post/controller/PostController.java
@@ -39,9 +39,6 @@ public class PostController {
      */
     @PostMapping("/posts")
     public ResponseDTO<Long> savePost(@Valid @RequestBody PostSaveRequestDTO dto, BindingResult result) {
-        if (result.hasErrors()) {
-            throw new InvalidPostParameterException(result, PostCrudErrorCode.POST_CRUD_FAIL);
-        }
         return new ResponseDTO<>(postService.savePost(dto), PostMessage.SAVE_POST_SUCCESS, HttpStatus.OK);
     }
 
@@ -57,9 +54,6 @@ public class PostController {
 
     @PatchMapping("/posts")
     public ResponseDTO<UpdatedPostDTO> updateOnePost(@Valid @RequestBody PostPatchRequestDTO dto, BindingResult result) {
-        if (result.hasErrors()) {
-            throw new InvalidPostParameterException(result, PostCrudErrorCode.POST_CRUD_FAIL);
-        }
         return new ResponseDTO<>(postService.updateOnePost(dto), PostMessage.UPDATE_POST_SUCCESS, HttpStatus.OK);
     }
 

--- a/src/main/java/study/tdd/simpleboard/exception/common/MainControllerAdvice.java
+++ b/src/main/java/study/tdd/simpleboard/exception/common/MainControllerAdvice.java
@@ -3,6 +3,7 @@ package study.tdd.simpleboard.exception.common;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -35,6 +36,23 @@ public class MainControllerAdvice {
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponseDTO> handleException(Exception e) {
         return handleGeneralException(HttpStatus.INTERNAL_SERVER_ERROR, e);
+    }
+
+    /**
+     *
+     * @Valid 에서 모든 파라미터가 비어있을경우 발생
+     *
+     * @param e
+     * @return
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponseDTO> catchIllegalArgumentException(HttpMessageNotReadableException e) {
+        // 직접 메시지 커스텀
+        ErrorResponseDTO errorResponseDTO = ErrorResponseDTO.builder()
+                .message("필수 항목이 모두 비어있습니다.")
+                .httpStatus(HttpStatus.NOT_FOUND)
+                .build();
+        return new ResponseEntity<>(errorResponseDTO, HttpStatus.NOT_FOUND);
     }
 
     /**


### PR DESCRIPTION
컨트롤러에서 공통로직으로 활용되는 BindingResult 를 AOP 를 활용하여 관점지향적으로 만들었습니다


추가된 클래스
```java
@Slf4j
@Component
@Aspect
public class BindingResultAop {


    /**
     *
     * api 패키지 내부 컨트롤러 실행전에 실행
     *
     * @param joinPoint
     * @return
     * @throws Throwable
     */
    @Before("execution(* study.tdd.simpleboard.api..*Controller.*(..))")
    public void bindingBefore(JoinPoint joinPoint) throws Throwable {
        for (Object arg : joinPoint.getArgs()) {
            if (arg instanceof BindingResult) {
                BindingResult result = (BindingResult) arg;

                if (result.hasErrors()) {
                    throw new InvalidPostParameterException(result, PostCrudErrorCode.POST_CRUD_FAIL);
                }

            }
        } // end for
    } // end

}
```